### PR TITLE
Add test suite for Telegram handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ Each user can choose their preferred AI personality:
 
 The bot logs important events and errors. Check the console output for debugging information.
 
+## Testing
+
+Unit tests live in the `tests/` directory and use `pytest` with
+`pytest-asyncio` for asynchronous handlers. Install the extra dependencies and
+run the suite from the project root:
+
+```bash
+pip install -r requirements.txt pytest pytest-asyncio
+pytest -q
+```
+
+See `tests/README.md` for a description of each test.
+
 ## Contributing
 
 1. Fork the repository

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -p no:warnings

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# Test Suite
+
+This directory contains unit tests for the Telegram handlers. The tests use
+`pytest` together with `pytest-asyncio` for running asynchronous code.
+
+## Running the tests
+
+1. Install dependencies (preferably in a virtual environment):
+   ```bash
+   pip install -r ../requirements.txt pytest pytest-asyncio
+   ```
+2. Execute the test suite from the repository root:
+   ```bash
+   pytest -q
+   ```
+
+## Test overview
+
+| Test name | Description |
+|-----------|-------------|
+| `test_mode_show_current` | Verifies that `/mode` without arguments returns the current AI mode. |
+| `test_mode_set_valid` | Checks that `/mode <mode>` switches to a valid mode and sends a confirmation. |
+| `test_prompt_invalid` | Ensures `/prompt <name>` with an unknown name replies with an error. |
+| `test_bot_reply_new_user` | Confirms the bot greets new users who reply to its messages. |
+| `test_offtopic_handler` | Tests the `/offtopic` command which starts a new conversation thread. |
+| `test_url_handler_generic` | Validates that URLs in regular messages trigger a generic link preview response. |
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import pytest
+from telegram.ext import ApplicationBuilder
+from telegram import Bot, User, Chat, Message, PhotoSize
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+@pytest.fixture()
+def application():
+    app = ApplicationBuilder().token("TEST_TOKEN").build()
+    app.bot._bot_user = User(99999, "Bot", True, username="ai_bot")
+    return app
+
+@pytest.fixture()
+def bot(application):
+    return application.bot
+
+def create_user(user_id=123, is_bot=False, first_name="User", username="user"):
+    return User(user_id, first_name, is_bot, username=username)
+
+def create_chat(chat_id=-100, title="Test Group"):
+    return Chat(chat_id, "group", title=title)
+
+def create_bot_message(bot, message_id=999, chat_id=-100):
+    bot_user = User(99999, "Bot", True, username="ai_bot")
+    data = {
+        "message_id": message_id,
+        "date": int(datetime.now().timestamp()),
+        "chat": create_chat(chat_id).to_dict(),
+        "from": bot_user.to_dict(),
+        "text": "Bot message",
+    }
+    return Message.de_json(data, bot)
+
+def create_message(bot, text=None, *, message_id=1, user_id=123, chat_id=-100,
+                   reply_to_bot=False, caption=None, photo=False, command=False):
+    data = {
+        "message_id": message_id,
+        "date": int(datetime.now().timestamp()),
+        "chat": create_chat(chat_id).to_dict(),
+        "from": create_user(user_id).to_dict(),
+    }
+    if text is not None:
+        data["text"] = text
+        if command:
+            data["entities"] = [{"type": "bot_command", "offset": 0, "length": len(text)}]
+    if caption is not None:
+        data["caption"] = caption
+    if photo:
+        p = PhotoSize(file_id="1", file_unique_id="1", width=10, height=10)
+        data["photo"] = [p.to_dict()]
+    if reply_to_bot:
+        data["reply_to_message"] = create_bot_message(bot).to_dict()
+    return Message.de_json(data, bot)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from telegram import Update
+from telegram.ext import CallbackContext
+from ai_companion import handlers
+from conftest import create_message
+
+# Dummy database stub
+class DummyDB:
+    def __init__(self):
+        self.register_user_called = False
+        self.register_message_called = False
+        self.checked_user = False
+
+    def register_chat(self, message):
+        self.register_chat_called = True
+
+    def register_user(self, user):
+        self.register_user_called = True
+
+    def register_message(self, message, message_sent):
+        self.register_message_called = True
+
+    def check_user(self, message):
+        self.checked_user = True
+        return False
+
+db_stub = DummyDB()
+
+@pytest.fixture(autouse=True)
+def patch_db(monkeypatch):
+    monkeypatch.setattr(handlers, "db", db_stub)
+    yield
+    handlers.global_prompt.reset()
+    handlers.service_prompt.reset()
+
+async def create_context(update, application):
+    ctx = CallbackContext.from_update(update, application)
+    ctx.args = []
+    return ctx
+
+@pytest.mark.asyncio
+async def test_mode_show_current(application, bot, monkeypatch):
+    message = create_message(bot, "/mode", command=True)
+    update = Update(update_id=1, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "get_user_ai_mode", lambda uid: "grok")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mode_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        args, kwargs = send_mock.call_args
+        assert "Current AI Mode" in kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_mode_set_valid(application, bot, monkeypatch):
+    message = create_message(bot, "/mode gpt", command=True)
+    update = Update(update_id=2, message=message)
+    context = await create_context(update, application)
+    context.args = ["gpt"]
+    monkeypatch.setattr(handlers, "set_user_ai_mode", lambda uid, mode: True)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mode_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "switched" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_prompt_invalid(application, bot, monkeypatch):
+    message = create_message(bot, "/prompt unknown", command=True)
+    update = Update(update_id=3, message=message)
+    context = await create_context(update, application)
+    context.args = ["unknown"]
+    monkeypatch.setattr(handlers, "set_user_prompt", lambda uid, name: False)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.prompt_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "Invalid" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_bot_reply_new_user(application, bot, monkeypatch):
+    message = create_message(bot, "Hello", reply_to_bot=True)
+    update = Update(update_id=4, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:hi")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.bot_reply_handler(update, context)
+        # two replies: greeting and answer
+        assert send_mock.await_count == 2
+
+@pytest.mark.asyncio
+async def test_offtopic_handler(application, bot, monkeypatch):
+    message = create_message(bot, "/offtopic blah", command=True)
+    update = Update(update_id=5, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:off")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.offtopic_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "off" in send_mock.call_args.kwargs["text"].lower()
+
+@pytest.mark.asyncio
+async def test_url_handler_generic(application, bot, monkeypatch):
+    text = "Check https://example.com"
+    message = create_message(bot, text)
+    update = Update(update_id=6, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:url")
+    monkeypatch.setattr(handlers, "generate_link_preview", lambda url: {"title": "t", "description": "d", "thumbnail": "x"})
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.url_msg_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "url" in send_mock.call_args.kwargs["text"].lower()


### PR DESCRIPTION
## Summary
- add pytest configuration
- implement fixtures for Telegram objects
- add comprehensive tests for command and message handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687123351c8483279eaaa44617f74c99