### PR TITLE
Add more Telegram handler tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ Each user can choose their preferred AI personality:
 
 The bot logs important events and errors. Check the console output for debugging information.
 
+## Testing
+
+Unit tests live in the `tests/` directory and use `pytest` with
+`pytest-asyncio` for asynchronous handlers. They cover bot commands,
+handling of images, new members joining, reply scenarios and more. Install the
+extra dependencies and run the suite from the project root:
+
+```bash
+pip install -r requirements.txt pytest pytest-asyncio
+pytest -q
+```
+
+See `tests/README.md` for a description of each test.
+
 ## Contributing
 
 1. Fork the repository

--- a/ai_companion/main.py
+++ b/ai_companion/main.py
@@ -24,7 +24,7 @@ def run():
     application.add_handler(MessageHandler(filters.REPLY, bot_reply_handler))
     application.add_handler(MessageHandler(filters.Entity("url"), url_msg_handler))
     application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, joined))
-    application.add_handler(MessageHandler(filters.UpdateType.MESSAGE & (~filters.ALL), ignore_private))
+    application.add_handler(MessageHandler(filters.ChatType.PRIVATE & ~filters.COMMAND, ignore_private))
     application.run_polling()
 
 if __name__ == "__main__":

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -p no:warnings

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,39 @@
+# Test Suite
+
+This directory contains unit tests for the Telegram handlers. The tests use
+`pytest` together with `pytest-asyncio` for running asynchronous code.
+
+## Running the tests
+
+1. Install dependencies (preferably in a virtual environment):
+   ```bash
+   pip install -r ../requirements.txt pytest pytest-asyncio
+   ```
+2. Execute the test suite from the repository root:
+   ```bash
+   pytest -q
+   ```
+
+## Test overview
+
+| Test name | Description |
+|-----------|-------------|
+| `test_mode_show_current` | Verifies that `/mode` without arguments returns the current AI mode. |
+| `test_mode_set_valid` | Checks that `/mode <mode>` switches to a valid mode and sends a confirmation. |
+| `test_prompt_invalid` | Ensures `/prompt <name>` with an unknown name replies with an error. |
+| `test_mode_set_invalid` | Passing an invalid mode shows an error message. |
+| `test_prompt_show_current` | `/prompt` without arguments shows the current prompt. |
+| `test_prompt_reload` | `/prompt reload` reloads prompt files. |
+| `test_bot_reply_new_user` | Confirms the bot greets new users who reply to its messages. |
+| `test_bot_reply_existing_user` | Ensures no greeting is sent when a known user replies again. |
+| `test_ignore_private` | Messages in private chats are ignored. |
+| `test_reply_not_to_bot` | Replying to another user triggers a single AI response without greeting. |
+| `test_offtopic_handler` | Tests the `/offtopic` command which starts a new conversation thread. |
+| `test_url_handler_generic` | Validates that URLs in regular messages trigger a generic link preview response. |
+| `test_url_handler_youtube` | YouTube links trigger video info lookup and AI reply. |
+| `test_photo_handler` | Sending a photo results in an AI reply after processing the image. |
+| `test_photo_handler_caption_url` | Photo caption URLs are parsed and included in the prompt. |
+| `test_joined_bot_added` | When the bot joins a group it sends a welcome message and registers the chat. |
+| `test_joined_regular_user` | No action is taken when a regular user joins the group. |
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import pytest
+from telegram.ext import ApplicationBuilder
+from telegram import (Bot, User, Chat, Message, PhotoSize, Audio, Document,
+                      Video, Voice, Sticker, Dice, Contact, Location, Poll,
+                      PollOption)
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+@pytest.fixture()
+def application():
+    app = ApplicationBuilder().token("TEST_TOKEN").build()
+    app.bot._bot_user = User(99999, "Bot", True, username="ai_bot")
+    return app
+
+@pytest.fixture()
+def bot(application):
+    return application.bot
+
+def create_user(user_id=123, is_bot=False, first_name="User", username="user"):
+    return User(user_id, first_name, is_bot, username=username)
+
+def create_chat(chat_id=-100, title="Test Group", chat_type="group"):
+    if chat_type == "private":
+        return Chat(chat_id, "private", first_name=title)
+    return Chat(chat_id, "group", title=title)
+
+def create_bot_message(bot, message_id=999, chat_id=-100):
+    bot_user = User(99999, "Bot", True, username="ai_bot")
+    data = {
+        "message_id": message_id,
+        "date": int(datetime.now().timestamp()),
+        "chat": create_chat(chat_id).to_dict(),
+        "from": bot_user.to_dict(),
+        "text": "Bot message",
+    }
+    return Message.de_json(data, bot)
+
+def create_message(bot, text=None, *, message_id=1, user_id=123, chat_id=-100,
+                   chat_type="group", reply_to_bot=False, reply_to_msg=None,
+                   caption=None, photo=False, command=False,
+                   audio=False, document=False, video=False, voice=False,
+                   sticker=False, dice=False, contact=False, location=False,
+                   poll=False):
+    data = {
+        "message_id": message_id,
+        "date": int(datetime.now().timestamp()),
+        "chat": create_chat(chat_id, chat_type=chat_type).to_dict(),
+        "from": create_user(user_id).to_dict(),
+    }
+    if text is not None:
+        data["text"] = text
+        if command:
+            data["entities"] = [{"type": "bot_command", "offset": 0, "length": len(text)}]
+    if caption is not None:
+        data["caption"] = caption
+    if photo:
+        p = PhotoSize(file_id="1", file_unique_id="1", width=10, height=10)
+        data["photo"] = [p.to_dict()]
+    if audio:
+        a = Audio(file_id="a", file_unique_id="a", duration=1)
+        data["audio"] = a.to_dict()
+    if document:
+        d = Document(file_id="d", file_unique_id="d")
+        data["document"] = d.to_dict()
+    if video:
+        v = Video(file_id="v", file_unique_id="v", width=1, height=1, duration=1)
+        data["video"] = v.to_dict()
+    if voice:
+        v = Voice(file_id="v", file_unique_id="v", duration=1)
+        data["voice"] = v.to_dict()
+    if sticker:
+        s = Sticker(file_id="s", file_unique_id="s", width=1, height=1,
+                     is_animated=False, is_video=False, type="regular")
+        data["sticker"] = s.to_dict()
+    if dice:
+        d = Dice(1, "🎲")
+        data["dice"] = d.to_dict()
+    if contact:
+        c = Contact("123", "User")
+        data["contact"] = c.to_dict()
+    if location:
+        l = Location(1.0, 1.0)
+        data["location"] = l.to_dict()
+    if poll:
+        p1 = PollOption("a", 0)
+        poll_obj = Poll("id", "q", [p1], 0, False, True, "regular", False)
+        data["poll"] = poll_obj.to_dict()
+    if reply_to_msg is not None:
+        data["reply_to_message"] = reply_to_msg.to_dict()
+    elif reply_to_bot:
+        data["reply_to_message"] = create_bot_message(bot).to_dict()
+    return Message.de_json(data, bot)
+
+def create_join_message(bot, members, *, message_id=1, chat_id=-100, user_id=321, chat_type="group"):
+    data = {
+        "message_id": message_id,
+        "date": int(datetime.now().timestamp()),
+        "chat": create_chat(chat_id, chat_type=chat_type).to_dict(),
+        "from": create_user(user_id).to_dict(),
+        "new_chat_members": [m.to_dict() for m in members],
+    }
+    return Message.de_json(data, bot)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,248 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from telegram import Update, Bot
+from telegram.ext import CallbackContext
+from ai_companion import handlers
+from conftest import create_message, create_join_message, create_user
+
+# Dummy database stub
+class DummyDB:
+    def __init__(self):
+        self.register_chat_called = False
+        self.register_user_called = False
+        self.register_message_called = False
+        self.checked_user = False
+
+    def register_chat(self, message):
+        self.register_chat_called = True
+
+    def register_user(self, user):
+        self.register_user_called = True
+
+    def register_message(self, message, message_sent):
+        self.register_message_called = True
+
+    def check_user(self, message):
+        self.checked_user = True
+        return False
+
+db_stub = DummyDB()
+
+@pytest.fixture(autouse=True)
+def patch_db(monkeypatch):
+    db_stub.__init__()
+    monkeypatch.setattr(handlers, "db", db_stub)
+    yield
+    handlers.global_prompt.reset()
+    handlers.service_prompt.reset()
+    db_stub.__init__()
+
+async def create_context(update, application):
+    ctx = CallbackContext.from_update(update, application)
+    ctx.args = []
+    return ctx
+
+@pytest.mark.asyncio
+async def test_mode_show_current(application, bot, monkeypatch):
+    message = create_message(bot, "/mode", command=True)
+    update = Update(update_id=1, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "get_user_ai_mode", lambda uid: "grok")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mode_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        args, kwargs = send_mock.call_args
+        assert "Current AI Mode" in kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_mode_set_valid(application, bot, monkeypatch):
+    message = create_message(bot, "/mode gpt", command=True)
+    update = Update(update_id=2, message=message)
+    context = await create_context(update, application)
+    context.args = ["gpt"]
+    monkeypatch.setattr(handlers, "set_user_ai_mode", lambda uid, mode: True)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mode_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "switched" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_prompt_invalid(application, bot, monkeypatch):
+    message = create_message(bot, "/prompt unknown", command=True)
+    update = Update(update_id=3, message=message)
+    context = await create_context(update, application)
+    context.args = ["unknown"]
+    monkeypatch.setattr(handlers, "set_user_prompt", lambda uid, name: False)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.prompt_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "Invalid" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_bot_reply_new_user(application, bot, monkeypatch):
+    message = create_message(bot, "Hello", reply_to_bot=True)
+    update = Update(update_id=4, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:hi")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.bot_reply_handler(update, context)
+        # two replies: greeting and answer
+        assert send_mock.await_count == 2
+
+@pytest.mark.asyncio
+async def test_offtopic_handler(application, bot, monkeypatch):
+    message = create_message(bot, "/offtopic blah", command=True)
+    update = Update(update_id=5, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:off")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.offtopic_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "off" in send_mock.call_args.kwargs["text"].lower()
+
+@pytest.mark.asyncio
+async def test_url_handler_generic(application, bot, monkeypatch):
+    text = "Check https://example.com"
+    message = create_message(bot, text)
+    update = Update(update_id=6, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:url")
+    monkeypatch.setattr(handlers, "generate_link_preview", lambda url: {"title": "t", "description": "d", "thumbnail": "x"})
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.url_msg_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "url" in send_mock.call_args.kwargs["text"].lower()
+
+@pytest.mark.asyncio
+async def test_photo_handler(application, bot, monkeypatch):
+    message = create_message(bot, caption="hi", photo=True)
+    update = Update(update_id=7, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "download_and_encode_image", AsyncMock(return_value=b"x"))
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:pic")
+    file_mock = AsyncMock(); file_mock.file_path = "https://x.com/p.jpg"
+    monkeypatch.setattr(Bot, "getFile", AsyncMock(return_value=file_mock))
+    from telegram.ext import ExtBot
+    monkeypatch.setattr(ExtBot, "getFile", AsyncMock(return_value=file_mock))
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.photo_msg_handler(update, context)
+        send_mock.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_joined_bot_added(application, bot, monkeypatch):
+    join_msg = create_join_message(bot, [bot._bot_user])
+    update = Update(update_id=8, message=join_msg)
+    context = await create_context(update, application)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.joined(update, context)
+        send_mock.assert_awaited_once()
+        assert db_stub.register_chat_called
+
+@pytest.mark.asyncio
+async def test_joined_regular_user(application, bot, monkeypatch):
+    join_msg = create_join_message(bot, [create_user(55)])
+    update = Update(update_id=9, message=join_msg)
+    context = await create_context(update, application)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.joined(update, context)
+        send_mock.assert_not_called()
+        assert db_stub.register_chat_called is False
+
+@pytest.mark.asyncio
+async def test_reply_not_to_bot(application, bot, monkeypatch):
+    other = create_message(bot, "hi", user_id=55, message_id=50)
+    message = create_message(bot, "reply", reply_to_msg=other, message_id=51)
+    update = Update(update_id=10, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:rep")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.bot_reply_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert not db_stub.checked_user
+
+@pytest.mark.asyncio
+async def test_bot_reply_existing_user(application, bot, monkeypatch):
+    message = create_message(bot, "hello", reply_to_bot=True)
+    update = Update(update_id=11, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(db_stub, "check_user", lambda m: True)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:hi")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.bot_reply_handler(update, context)
+        send_mock.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_mode_set_invalid(application, bot, monkeypatch):
+    message = create_message(bot, "/mode invalid", command=True)
+    update = Update(update_id=12, message=message)
+    context = await create_context(update, application)
+    context.args = ["invalid"]
+    monkeypatch.setattr(handlers, "set_user_ai_mode", lambda uid, mode: False)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mode_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "Invalid" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_prompt_show_current(application, bot, monkeypatch):
+    message = create_message(bot, "/prompt", command=True)
+    update = Update(update_id=13, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "get_user_prompt", lambda uid: "dan")
+    monkeypatch.setattr(handlers.prompt_loader, "list_prompts", lambda: ["dan", "friendly"])
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.prompt_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "Current Prompt" in send_mock.call_args.kwargs["text"]
+
+@pytest.mark.asyncio
+async def test_prompt_reload(application, bot, monkeypatch):
+    message = create_message(bot, "/prompt reload", command=True)
+    update = Update(update_id=14, message=message)
+    context = await create_context(update, application)
+    context.args = ["reload"]
+    monkeypatch.setattr(handlers.prompt_loader, "reload_prompts", lambda: None)
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.prompt_command_handler(update, context)
+        send_mock.assert_awaited_once()
+        assert "reloaded" in send_mock.call_args.kwargs["text"].lower()
+
+@pytest.mark.asyncio
+async def test_ignore_private(application, bot):
+    message = create_message(bot, "hi", chat_id=100, chat_type="private")
+    update = Update(update_id=15, message=message)
+    context = await create_context(update, application)
+    with patch("telegram.Message.reply_text", new=AsyncMock()) as send_mock:
+        await handlers.ignore_private(update, context)
+        send_mock.assert_awaited_once_with('I only respond in group chats!')
+
+@pytest.mark.asyncio
+async def test_url_handler_youtube(application, bot, monkeypatch):
+    text = "Check https://youtu.be/abcdefghijk"
+    message = create_message(bot, text)
+    update = Update(update_id=16, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "extract_video_id", lambda url: "abcdefghijk", raising=False)
+    monkeypatch.setattr(handlers, "get_video_info_api", lambda vid: {"title": "t", "description": "d", "thumbnail": "th", "channelname": "c"})
+    monkeypatch.setattr(handlers, "get_highest_rated_comments", lambda vid: ["c1"])
+    monkeypatch.setattr(handlers, "helpers", type("H", (), {"escape_markdown": lambda t: t}), raising=False)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:yt")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.url_msg_handler(update, context)
+        assert send_mock.await_count == 2
+
+@pytest.mark.asyncio
+async def test_photo_handler_caption_url(application, bot, monkeypatch):
+    message = create_message(bot, caption="Check https://example.com", photo=True)
+    update = Update(update_id=17, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "download_and_encode_image", AsyncMock(return_value=b"x"))
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:pic")
+    file_mock = AsyncMock(); file_mock.file_path = "https://x.com/p.jpg"
+    monkeypatch.setattr(Bot, "getFile", AsyncMock(return_value=file_mock))
+    from telegram.ext import ExtBot
+    monkeypatch.setattr(ExtBot, "getFile", AsyncMock(return_value=file_mock))
+    monkeypatch.setattr(handlers, "generate_link_preview", lambda url: {"title": "t", "description": "d", "thumbnail": "x"})
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.photo_msg_handler(update, context)
+        send_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- expand testing helpers to cover many Telegram content types
- add tests for invalid mode, prompt commands, private chats, YouTube links and caption URLs
- document all tests in test README
- clarify README test section and fix private chat handler filter

## Testing
- `pip install -r requirements.txt pytest pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687123351c8483279eaaa44617f74c99