### PR TITLE
Fix handlers and persist preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Telegram AI Companion is a Python-based Telegram bot that can engage in intellig
 - **Group Message Engagement**: Engages with both text and image messages in a group setting
 - **YouTube Integration**: Special handling for YouTube links with video information and thumbnail analysis
 - **Link Preview**: Automatic link analysis and preview generation with image understanding
-- **Persistent Preferences**: User preferences for AI mode and prompts are remembered
+- **Persistent Preferences**: User preferences for AI mode and prompts are stored in the SQLite database
+- **Automatic Thread Reset**: Conversations reset after 10 exchanges to avoid hitting token limits
 ## Architecture
 
 The bot is organized as a Python package `ai_companion` separating AI providers, prompt management, handlers and utilities. The `bot.py` entry point simply calls `ai_companion.main.run()`.

--- a/ai_companion/ai.py
+++ b/ai_companion/ai.py
@@ -2,6 +2,7 @@ import logging
 import os
 import base64
 import urllib.request
+import tempfile
 from openai import OpenAI
 from .config import OPENAI_API_KEY, XAI_API_KEY
 
@@ -22,10 +23,11 @@ def download_and_encode_image(file_url):
         opener = urllib.request.build_opener()
         opener.addheaders = list(headers.items())
         urllib.request.install_opener(opener)
-        urllib.request.urlretrieve(file_url, 'temp_image.jpg')
-        with open('temp_image.jpg', 'rb') as image_file:
-            image_data = base64.b64encode(image_file.read()).decode('utf-8')
-        os.remove('temp_image.jpg')
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.jpg') as tmp:
+            urllib.request.urlretrieve(file_url, tmp.name)
+            tmp.seek(0)
+            image_data = base64.b64encode(tmp.read()).decode('utf-8')
+        os.remove(tmp.name)
         return image_data
     except Exception as e:
         logger.error(f"Error downloading/encoding image: {e}")

--- a/ai_companion/db.py
+++ b/ai_companion/db.py
@@ -131,3 +131,69 @@ class DBsqlite:
             logging.debug("An error occurred: %s", error)
             logging.debug("For the statement: %s", statement)
             return None
+
+    def get_all_preferences(self):
+        """Return a dict of user preferences keyed by Telegram user id."""
+        self.connect()
+        try:
+            rows = self.cursor.execute(
+                "SELECT u.tuser_id as tuser_id, p.ai_mode, p.system_prompt "
+                "FROM user_preferences p JOIN users u ON p.user_id=u.id"
+            ).fetchall()
+            prefs = {}
+            for row in rows:
+                prefs[row["tuser_id"]] = {
+                    "ai_mode": row["ai_mode"],
+                    "system_prompt": row["system_prompt"],
+                }
+            return prefs
+        except sqlite3.Error as error:
+            logging.error("Database error in get_all_preferences: %s", error)
+            return {}
+
+    def save_user_ai_mode(self, tuser_id: int, mode: str) -> None:
+        """Persist user's preferred AI mode."""
+        self.connect()
+        try:
+            row = self.cursor.execute(
+                "SELECT id FROM users WHERE tuser_id=?",
+                (tuser_id,),
+            ).fetchone()
+            if not row:
+                return
+            user_id = row["id"]
+            self.cursor.execute(
+                "INSERT OR IGNORE INTO user_preferences (user_id, ai_mode, system_prompt) VALUES (?, ?, 'dan')",
+                (user_id, mode),
+            )
+            self.cursor.execute(
+                "UPDATE user_preferences SET ai_mode=? WHERE user_id=?",
+                (mode, user_id),
+            )
+            self.connection.commit()
+        except sqlite3.Error as error:
+            logging.error("Database error in save_user_ai_mode: %s", error)
+
+    def save_user_prompt(self, tuser_id: int, prompt_name: str) -> None:
+        """Persist user's preferred system prompt."""
+        self.connect()
+        try:
+            row = self.cursor.execute(
+                "SELECT id FROM users WHERE tuser_id=?",
+                (tuser_id,),
+            ).fetchone()
+            if not row:
+                return
+            user_id = row["id"]
+            self.cursor.execute(
+                "INSERT OR IGNORE INTO user_preferences (user_id, ai_mode, system_prompt) VALUES (?, 'grok', ?)",
+                (user_id, prompt_name),
+            )
+            self.cursor.execute(
+                "UPDATE user_preferences SET system_prompt=? WHERE user_id=?",
+                (prompt_name, user_id),
+            )
+            self.connection.commit()
+        except sqlite3.Error as error:
+            logging.error("Database error in save_user_prompt: %s", error)
+

--- a/ai_companion/handlers.py
+++ b/ai_companion/handlers.py
@@ -43,6 +43,11 @@ def init_database():
         return DBsqlite(DB_FILENAME, schema)
 
 db = init_database()
+try:
+    from .prompts import set_db_instance
+    set_db_instance(db)
+except Exception:
+    logger.debug("Could not attach DB instance to prompts")
 
 dan_prompt = [{"role": "system", "content": prompt_loader.get_prompt('dan') or 'You are a friendly assistant'}]
 
@@ -76,8 +81,9 @@ async def mode_command_handler(update: Update, context: CallbackContext) -> None
     user_id = message.from_user.id
     args = context.args
     if not args:
+        from .ai import openai_client
         current_mode = get_user_ai_mode(user_id)
-        available_modes = "grok" + (", gpt" if user_ai_modes else "")
+        available_modes = "grok" + (", gpt" if openai_client else "")
         await message.reply_text(
             f"🤖 <b>Current AI Mode:</b> {current_mode.upper()}\n"
             f"📋 <b>Available modes:</b> {available_modes}",
@@ -157,45 +163,59 @@ async def bot_reply_handler(update: Update, context: CallbackContext) -> None:
 
     user_id = message.from_user.id
 
-    # Check if this is a reply to the bot
-    if not message.reply_to_message:
-        return
-
-    if not message.reply_to_message.from_user:
-        return
-
-    if message.reply_to_message.from_user.id != context.bot.id:
-        return
-        # Check if this is a new user (hasn't interacted before)
-        is_new_user = not db.check_user(message)
-
-        if is_new_user:
-            # Register the user first so they won't be considered new again
-            db.register_user(message.from_user)
-
-            # Send new user greeting
-            new_user_prompt = "You're in Telegram chat, where a user has interacted with you for the first time, write a greeting message to him."
-            if message.from_user.first_name:
-                new_user_prompt += f" First name: {message.from_user.first_name}."
-            new_user_greeting = extract_dan(generic_chat(service_prompt, new_user_prompt, user_id, ai_mode=get_user_ai_mode(user_id)))
-            usage = f"<span class=\"tg-spoiler\">{print_usage()}</span>"
-            await message.reply_text(f"{new_user_greeting}\n\n{usage}", parse_mode=ParseMode.HTML)
-
-        # Always respond to the actual message content
+    # If the reply is not directed at the bot, simply respond without greeting
+    if not (
+        message.reply_to_message
+        and message.reply_to_message.from_user
+        and message.reply_to_message.from_user.id == context.bot.id
+    ):
         try:
-            response = extract_dan(generic_chat(global_prompt, message.text, user_id, ai_mode=get_user_ai_mode(user_id)))
-
-            # Register user if not already done (for non-new users)
-            if not is_new_user:
-                db.register_user(message.from_user)
-
-            # Register this message interaction
+            response = extract_dan(
+                generic_chat(global_prompt, message.text, user_id, ai_mode=get_user_ai_mode(user_id))
+            )
             db.register_message(message, message)
             reply = await message.reply_text(response, parse_mode=ParseMode.HTML)
             global_prompt.conversation.add_message(reply)
         except Exception as e:
             logger.error(f"Error in bot reply: {e}")
-            await message.reply_text("Sorry, I'm experiencing technical difficulties. Please try again later.")
+            await message.reply_text(
+                "Sorry, I'm experiencing technical difficulties. Please try again later."
+            )
+        return
+
+    # Determine if this user interacted before in this chat
+    is_new_user = not db.check_user(message)
+
+    if is_new_user:
+        db.register_user(message.from_user)
+        new_user_prompt = (
+            "You're in Telegram chat, where a user has interacted with you for the first time, write a greeting message to him."
+        )
+        if message.from_user.first_name:
+            new_user_prompt += f" First name: {message.from_user.first_name}."
+        new_user_greeting = extract_dan(
+            generic_chat(service_prompt, new_user_prompt, user_id, ai_mode=get_user_ai_mode(user_id))
+        )
+        usage = f"<span class=\"tg-spoiler\">{print_usage()}</span>"
+        await message.reply_text(f"{new_user_greeting}\n\n{usage}", parse_mode=ParseMode.HTML)
+
+    # Respond to the actual message content
+    try:
+        response = extract_dan(
+            generic_chat(global_prompt, message.text, user_id, ai_mode=get_user_ai_mode(user_id))
+        )
+
+        if not is_new_user:
+            db.register_user(message.from_user)
+
+        db.register_message(message, message)
+        reply = await message.reply_text(response, parse_mode=ParseMode.HTML)
+        global_prompt.conversation.add_message(reply)
+    except Exception as e:
+        logger.error(f"Error in bot reply: {e}")
+        await message.reply_text(
+            "Sorry, I'm experiencing technical difficulties. Please try again later."
+        )
 
 async def photo_msg_handler(update: Update, context: CallbackContext) -> None:
     message = update.message

--- a/ai_companion/prompts.py
+++ b/ai_companion/prompts.py
@@ -1,7 +1,9 @@
 import os
 import uuid
 import logging
-from .config import DEFAULT_AI_MODE
+from .config import DEFAULT_AI_MODE, DB_FILENAME
+from .db import DBsqlite
+from .ai import openai_client
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,28 @@ DEFAULT_PROMPT = "dan"
 user_prompts = {}
 user_ai_modes = {}
 
+# Optional database instance for persisting preferences
+db_instance: DBsqlite | None = None
+
+def set_db_instance(db: DBsqlite):
+    """Attach a DB instance and load stored preferences."""
+    global db_instance
+    db_instance = db
+    load_preferences_from_db()
+
+def load_preferences_from_db():
+    if not db_instance:
+        return
+    try:
+        prefs = db_instance.get_all_preferences()
+        for uid, pref in prefs.items():
+            if pref.get("ai_mode"):
+                user_ai_modes[uid] = pref["ai_mode"]
+            if pref.get("system_prompt"):
+                user_prompts[uid] = pref["system_prompt"]
+    except Exception as exc:
+        logger.error("Failed loading preferences: %s", exc)
+
 class Conversation:
     def __init__(self):
         self.id = uuid.uuid4()
@@ -78,12 +102,13 @@ class PromptManager:
         self.calls = 0
         self.conversation.reset()
 
-    def communicate(self, text:str):
-        if self.calls < self.reset_after_calls:
-            self._prompt.append({"role":"user","content":text})
-            self.calls += 1
-            return self._prompt
-        raise ValueError("Maximum number of calls reached")
+    def communicate(self, text: str):
+        """Append user text, resetting conversation if needed."""
+        if self.calls >= self.reset_after_calls:
+            self.reset()
+        self._prompt.append({"role": "user", "content": text})
+        self.calls += 1
+        return self._prompt
 
     def save_feedback(self, text:str):
         self._prompt.append({"role":"assistant","content":text})
@@ -98,7 +123,18 @@ def get_user_ai_mode(user_id):
     return user_ai_modes.get(user_id, DEFAULT_AI_MODE)
 
 def set_user_ai_mode(user_id, mode):
+    mode = mode.lower()
+    valid = {"grok", "gpt"}
+    if mode not in valid:
+        return False
+    if mode == "gpt" and not openai_client:
+        return False
     user_ai_modes[user_id] = mode
+    if db_instance:
+        try:
+            db_instance.save_user_ai_mode(user_id, mode)
+        except Exception as exc:
+            logger.error("Failed to save AI mode: %s", exc)
     return True
 
 def get_user_prompt(user_id):
@@ -107,6 +143,11 @@ def get_user_prompt(user_id):
 def set_user_prompt(user_id, prompt_name):
     if prompt_name in prompt_loader.list_prompts():
         user_prompts[user_id] = prompt_name
+        if db_instance:
+            try:
+                db_instance.save_user_prompt(user_id, prompt_name)
+            except Exception as exc:
+                logger.error("Failed to save prompt: %s", exc)
         return True
     return False
 

--- a/db.schema
+++ b/db.schema
@@ -48,3 +48,9 @@ CREATE TABLE IF NOT EXISTS "chats" (
 CREATE INDEX IF NOT EXISTS idx_users_tuser_id ON users(tuser_id);
 CREATE INDEX IF NOT EXISTS idx_chats_tchat_id ON chats(tchat_id);
 CREATE INDEX IF NOT EXISTS idx_messages_user_chat ON messages(user_id, chat_id);
+CREATE TABLE IF NOT EXISTS "user_preferences" (
+        "user_id" INTEGER PRIMARY KEY,
+        "ai_mode" TEXT DEFAULT 'grok',
+        "system_prompt" TEXT DEFAULT 'dan',
+        FOREIGN KEY("user_id") REFERENCES "users"("id")
+);


### PR DESCRIPTION
## Summary
- add persistence table `user_preferences`
- save AI mode and prompt selections in the database
- use temp files for image downloads
- automatically reset conversation threads
- improve `/mode` output and reply handler logic
- update documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b898ed9083279407e7bf403523a6