### PR TITLE
Restrict bot reactions to mentions or replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Telegram AI Companion is a Python-based Telegram bot that can engage in intellig
 - **Link Preview**: Automatic link analysis and preview generation with image understanding
 - **Persistent Preferences**: User preferences for AI mode and prompts are stored in the SQLite database
 - **Conversation Memory**: Up to 50 recent exchanges per user are stored in a circular buffer, with important notes preserved
+- **Mention or Reply Activation**: The bot only responds when tagged or when users reply directly to its messages
 - **Automatic Thread Reset**: Conversations reset after 10 exchanges to avoid hitting token limits
 - **Concise Default Prompt**: The bot now uses a short, specific personality prompt by default
 ## Architecture
@@ -118,6 +119,7 @@ The bot is organized as a Python package `ai_companion` separating AI providers,
 ### Other Commands
 - `/offtopic [message]` - Start a new conversation topic
 - Reply to any bot message to continue the conversation
+  (messages without a mention or reply are ignored)
 
 ## System Prompts
 

--- a/ai_companion/handlers.py
+++ b/ai_companion/handlers.py
@@ -180,31 +180,12 @@ async def bot_reply_handler(update: Update, context: CallbackContext) -> None:
 
     user_id = message.from_user.id
 
-    # If the reply is not directed at the bot, simply respond without greeting
+    # Ignore replies not directed at the bot
     if not (
         message.reply_to_message
         and message.reply_to_message.from_user
         and message.reply_to_message.from_user.id == context.bot.id
     ):
-        try:
-            global_prompt.reset()
-            history_prompt = get_prompt_with_history(user_id, db)
-            global_prompt.initial_prompt = history_prompt
-            global_prompt._prompt = history_prompt.copy()
-            db.register_user(message.from_user)
-            db.add_history(user_id, "user", message.text)
-            response = extract_dan(
-                generic_chat(global_prompt, message.text, user_id, ai_mode=get_user_ai_mode(user_id))
-            )
-            db.add_history(user_id, "assistant", response)
-            db.register_message(message, message)
-            reply = await message.reply_text(response, parse_mode=ParseMode.HTML)
-            global_prompt.conversation.add_message(reply)
-        except Exception as e:
-            logger.error(f"Error in bot reply: {e}")
-            await message.reply_text(
-                "Sorry, I'm experiencing technical difficulties. Please try again later."
-            )
         return
 
     # Determine if this user interacted before in this chat
@@ -212,6 +193,8 @@ async def bot_reply_handler(update: Update, context: CallbackContext) -> None:
 
     if is_new_user:
         db.register_user(message.from_user)
+        if message.reply_to_message and message.reply_to_message.text:
+            db.add_history(user_id, "assistant", message.reply_to_message.text, important=True)
         photo_data = None
         try:
             photos = await context.bot.get_user_profile_photos(user_id, limit=1)
@@ -273,6 +256,16 @@ async def photo_msg_handler(update: Update, context: CallbackContext) -> None:
     message = update.message
     if not message.from_user:
         return
+    bot_username = context.bot.username
+    if not (
+        (message.caption and f"@{bot_username}" in message.caption)
+        or (
+            message.reply_to_message
+            and message.reply_to_message.from_user
+            and message.reply_to_message.from_user.id == context.bot.id
+        )
+    ):
+        return
     user_id = message.from_user.id
     photo = await context.bot.getFile(message.photo[-1].file_id)
     photo_url = photo.file_path
@@ -281,6 +274,8 @@ async def photo_msg_handler(update: Update, context: CallbackContext) -> None:
         photo_url = f"https://api.telegram.org/file/bot{bot_token}/{photo.file_path}"
     image_data = download_and_encode_image(photo_url)
     msg_caption = message.caption or ""
+    if f"@{bot_username}" in msg_caption:
+        msg_caption = msg_caption.replace(f"@{bot_username}", "").strip()
     caption_urls = ''
     if msg_caption:
         caption_url_list = find_url(msg_caption)
@@ -320,7 +315,19 @@ async def url_msg_handler(update: Update, context: CallbackContext) -> None:
     message = update.message
     if not message.from_user:
         return
+    bot_username = context.bot.username
+    if not (
+        f"@{bot_username}" in message.text
+        or (
+            message.reply_to_message
+            and message.reply_to_message.from_user
+            and message.reply_to_message.from_user.id == context.bot.id
+        )
+    ):
+        return
     text = message.text
+    if f"@{bot_username}" in text:
+        text = text.replace(f"@{bot_username}", "").strip()
     url = extract_first_url(text)
     body = text.replace(url, '')
     user_id = message.from_user.id

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 from telegram import Update, Bot
 from telegram.ext import CallbackContext
 from ai_companion import handlers
-from conftest import create_message, create_join_message, create_user
+from conftest import create_message, create_join_message, create_user, create_bot_message
 
 # Dummy database stub
 class DummyDB:
@@ -12,9 +12,10 @@ class DummyDB:
         self.register_user_called = False
         self.register_message_called = False
         self.checked_user = False
+        self.history = []
 
     def add_history(self, uid, role, content, important=False):
-        pass
+        self.history.append((uid, role, content, important))
 
     def get_history(self, uid, limit=10):
         return []
@@ -108,7 +109,7 @@ async def test_offtopic_handler(application, bot, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_url_handler_generic(application, bot, monkeypatch):
-    text = "Check https://example.com"
+    text = "@ai_bot Check https://example.com"
     message = create_message(bot, text)
     update = Update(update_id=6, message=message)
     context = await create_context(update, application)
@@ -121,7 +122,7 @@ async def test_url_handler_generic(application, bot, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_photo_handler(application, bot, monkeypatch):
-    message = create_message(bot, caption="hi", photo=True)
+    message = create_message(bot, caption="@ai_bot hi", photo=True)
     update = Update(update_id=7, message=message)
     context = await create_context(update, application)
     monkeypatch.setattr(handlers, "download_and_encode_image", AsyncMock(return_value=b"x"))
@@ -163,7 +164,7 @@ async def test_reply_not_to_bot(application, bot, monkeypatch):
     monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:rep")
     with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
         await handlers.bot_reply_handler(update, context)
-        send_mock.assert_awaited_once()
+        send_mock.assert_not_called()
         assert not db_stub.checked_user
 
 @pytest.mark.asyncio
@@ -224,7 +225,7 @@ async def test_ignore_private(application, bot):
 
 @pytest.mark.asyncio
 async def test_url_handler_youtube(application, bot, monkeypatch):
-    text = "Check https://youtu.be/abcdefghijk"
+    text = "@ai_bot Check https://youtu.be/abcdefghijk"
     message = create_message(bot, text)
     update = Update(update_id=16, message=message)
     context = await create_context(update, application)
@@ -239,7 +240,7 @@ async def test_url_handler_youtube(application, bot, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_photo_handler_caption_url(application, bot, monkeypatch):
-    message = create_message(bot, caption="Check https://example.com", photo=True)
+    message = create_message(bot, caption="@ai_bot Check https://example.com", photo=True)
     update = Update(update_id=17, message=message)
     context = await create_context(update, application)
     monkeypatch.setattr(handlers, "download_and_encode_image", AsyncMock(return_value=b"x"))
@@ -252,3 +253,16 @@ async def test_photo_handler_caption_url(application, bot, monkeypatch):
     with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
         await handlers.photo_msg_handler(update, context)
         send_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reply_fork_new_user(application, bot, monkeypatch):
+    replied = create_bot_message(bot, message_id=60)
+    message = create_message(bot, "fork", reply_to_msg=replied, message_id=61, user_id=55)
+    update = Update(update_id=18, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers, "generic_chat", lambda *a, **k: "DAN:fork")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.bot_reply_handler(update, context)
+        assert send_mock.await_count == 2
+    assert (55, "assistant", "Bot message", True) in db_stub.history


### PR DESCRIPTION
## Summary
- update README to note mention-only behavior
- ignore messages that aren't replies to the bot
- remember replied message when a new user forks a conversation
- require a mention or reply for photo and link handlers
- adapt tests for the new logic and cover conversation forking

## Testing
- `pip install -r requirements.txt pytest pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b1f96d608327852f5baeb399b307