### PR TITLE
Improve bot interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,30 @@ Each user can choose their preferred AI personality:
 - Extracts title, description, and images
 - AI provides commentary on linked content
 
+## Message Types Handling
+
+Telegram delivers many kinds of updates. The bot focuses on a few that make
+sense for conversational AI while ignoring others:
+
+| Message type                 | Current behaviour |
+|------------------------------|------------------|
+| Text mention or reply        | Triggers an AI response. When replying to a
+message and tagging the bot, the original text is included so the AI has
+context. |
+| Text containing URLs         | Generates a link preview and asks the AI to
+comment on it. YouTube links receive special handling. |
+| Photo messages               | Downloaded and analysed by the AI when the bot
+is mentioned or the photo replies to it. |
+| Forwarded messages           | If a post is forwarded from a channel or
+another chat, the bot gives its perspective on the forwarded text. |
+| Channel posts in linked chats| Channel posts appearing in a group trigger an
+AI response summarising or commenting on the post. |
+| Reactions to bot messages    | Negative or strange emoji reactions prompt a
+short reply from the bot. |
+| Other media (audio, voice,
+sticker, location, etc.) | Currently ignored to keep conversations focused.
+
+
 ## Troubleshooting
 
 ### Common Issues

--- a/ai_companion/db.py
+++ b/ai_companion/db.py
@@ -264,3 +264,15 @@ class DBsqlite:
             logging.error("Database error in get_history: %s", exc)
             return []
 
+    async def is_bot_message(self, tmsg_id: int) -> bool:
+        """Return True if we have stored a message with this Telegram ID."""
+        await self.connect()
+        try:
+            cur = await self.connection.execute(
+                "SELECT 1 FROM messages WHERE tmsg_id=?", (tmsg_id,)
+            )
+            return await cur.fetchone() is not None
+        except Exception as exc:
+            logging.error("Database error in is_bot_message: %s", exc)
+            return False
+

--- a/ai_companion/handlers/__init__.py
+++ b/ai_companion/handlers/__init__.py
@@ -69,8 +69,10 @@ from .messages import (
     joined,
     ignore_private,
     channel_message_handler,
+    forward_message_handler,
     mention_handler,
     bot_reply_handler,
+    reaction_handler,
     global_prompt as _g2, service_prompt as _s2, DB as _db2,
 )
 from .media import (
@@ -94,8 +96,10 @@ __all__ = [
     'joined',
     'ignore_private',
     'channel_message_handler',
+    'forward_message_handler',
     'mention_handler',
     'bot_reply_handler',
+    'reaction_handler',
     'photo_msg_handler',
     'url_msg_handler',
     'generic_chat',

--- a/ai_companion/handlers/messages.py
+++ b/ai_companion/handlers/messages.py
@@ -26,6 +26,9 @@ from ..db import DBsqlite
 
 logger = logging.getLogger(__name__)
 
+NEGATIVE_REACTIONS = {"😡", "👎", "🤬", "🤮"}
+WEIRD_REACTIONS = {"🤯", "🥴", "🤪", "😳"}
+
 # provided by __init__.py
 global_prompt: PromptManager | None = None
 service_prompt: ServicePrompt | None = None
@@ -52,6 +55,32 @@ async def channel_message_handler(update: Update, context: CallbackContext) -> N
     except Exception as e:
         logger.error(f"Error handling channel message: {e}")
 
+async def forward_message_handler(update: Update, context: CallbackContext) -> None:
+    """Handle forwarded messages from other chats or channels."""
+    message = update.message
+    if not message or not (message.forward_origin or message.forward_from_chat or message.forward_from):
+        return
+    user_id = message.from_user.id if message.from_user else message.chat_id
+    origin = "a chat"
+    if message.forward_origin and getattr(message.forward_origin, 'title', None):
+        origin = message.forward_origin.title
+    elif message.forward_from_chat:
+        origin = message.forward_from_chat.title or message.forward_from_chat.username or origin
+    elif message.forward_from:
+        origin = message.forward_from.full_name
+    text = message.text or message.caption or ""
+    prompt = f"A message was forwarded from {origin}: {text}"
+    try:
+        global_prompt.reset()
+        history_prompt = await get_prompt_with_history(user_id, DB)
+        global_prompt.initial_prompt = history_prompt
+        global_prompt._prompt = history_prompt.copy()
+        response = extract_dan(generic_chat(global_prompt, prompt, user_id, ai_mode=get_user_ai_mode(user_id)))
+        reply = await message.reply_text(response, parse_mode=ParseMode.HTML)
+        global_prompt.conversation.add_message(reply)
+    except Exception as e:
+        logger.error(f"Error handling forwarded message: {e}")
+
 async def joined(update: Update, context: CallbackContext) -> None:
     for member in update.message.new_chat_members:
         if member.username == context.bot.username:
@@ -73,6 +102,10 @@ async def mention_handler(update: Update, context: CallbackContext) -> None:
     bot_username = context.bot.username
     if f"@{bot_username}" in message.text or message.text.startswith(f"@{bot_username}"):
         text = message.text.replace(f"@{bot_username}", "").strip() or "Hello!"
+        if message.reply_to_message:
+            original = message.reply_to_message.text or message.reply_to_message.caption or ""
+            if original:
+                text = f"In reply to: \"{original}\"\n{text}"
         try:
             global_prompt.reset()
             history_prompt = await get_prompt_with_history(user_id, DB)
@@ -157,4 +190,35 @@ async def bot_reply_handler(update: Update, context: CallbackContext) -> None:
         await message.reply_text(
             "Sorry, I'm experiencing technical difficulties. Please try again later."
         )
+
+async def reaction_handler(update: Update, context: CallbackContext) -> None:
+    """Respond to negative or weird reactions to bot messages."""
+    r = update.message_reaction
+    if not r or not r.new_reaction:
+        return
+    try:
+        if not await DB.is_bot_message(r.message_id):
+            return
+    except Exception as e:
+        logger.error(f"Error checking message for reaction: {e}")
+        return
+    emoji = None
+    for react in r.new_reaction:
+        if getattr(react, "emoji", None) in NEGATIVE_REACTIONS | WEIRD_REACTIONS:
+            emoji = react.emoji
+            break
+    if not emoji:
+        return
+    user = r.user or r.actor_chat
+    user_id = user.id if user else r.chat.id
+    prompt = f"A user reacted with {emoji} to my previous message. Reply briefly."
+    try:
+        global_prompt.reset()
+        history_prompt = await get_prompt_with_history(user_id, DB)
+        global_prompt.initial_prompt = history_prompt
+        global_prompt._prompt = history_prompt.copy()
+        response = extract_dan(generic_chat(global_prompt, prompt, user_id, ai_mode=get_user_ai_mode(user_id)))
+        await context.bot.send_message(r.chat.id, response, reply_to_message_id=r.message_id, parse_mode=ParseMode.HTML)
+    except Exception as e:
+        logger.error(f"Error handling reaction: {e}")
 

--- a/ai_companion/main.py
+++ b/ai_companion/main.py
@@ -2,7 +2,13 @@ import logging
 import time
 import socket
 import asyncio
-from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, filters
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    MessageReactionHandler,
+    filters,
+)
 from telegram.error import NetworkError, TimedOut
 from .config import TELEGRAM_BOT_TOKEN
 from .handlers import (
@@ -16,7 +22,9 @@ from .handlers import (
     url_msg_handler,
     ignore_private,
     channel_message_handler,
-    mention_handler
+    mention_handler,
+    forward_message_handler,
+    reaction_handler,
 )
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
@@ -74,6 +82,8 @@ def run():
             application.add_handler(MessageHandler(filters.Entity("url") & filters.USER, url_msg_handler))
             application.add_handler(MessageHandler(filters.Entity("mention") & filters.USER, mention_handler))
             application.add_handler(MessageHandler(filters.SenderChat(), channel_message_handler))
+            application.add_handler(MessageHandler(filters.FORWARDED & filters.USER, forward_message_handler))
+            application.add_handler(MessageReactionHandler(reaction_handler))
             application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, joined))
             application.add_handler(MessageHandler(filters.ChatType.PRIVATE & ~filters.COMMAND, ignore_private))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def create_message(bot, text=None, *, message_id=1, user_id=123, chat_id=-100,
                    caption=None, photo=False, command=False,
                    audio=False, document=False, video=False, voice=False,
                    sticker=False, dice=False, contact=False, location=False,
-                   poll=False):
+                   poll=False, forward_from_chat=None, forward_from_user=None, automatic=False):
     data = {
         "message_id": message_id,
         "date": int(datetime.now().timestamp()),
@@ -88,6 +88,12 @@ def create_message(bot, text=None, *, message_id=1, user_id=123, chat_id=-100,
         p1 = PollOption("a", 0)
         poll_obj = Poll("id", "q", [p1], 0, False, True, "regular", False)
         data["poll"] = poll_obj.to_dict()
+    if forward_from_chat is not None:
+        data["forward_from_chat"] = forward_from_chat.to_dict()
+    if forward_from_user is not None:
+        data["forward_from"] = forward_from_user.to_dict()
+    if automatic:
+        data["is_automatic_forward"] = True
     if reply_to_msg is not None:
         data["reply_to_message"] = reply_to_msg.to_dict()
     elif reply_to_bot:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,7 +3,13 @@ from unittest.mock import AsyncMock, patch
 from telegram import Update, Bot
 from telegram.ext import CallbackContext
 from ai_companion import handlers
-from conftest import create_message, create_join_message, create_user, create_bot_message
+from conftest import (
+    create_message,
+    create_join_message,
+    create_user,
+    create_bot_message,
+    create_chat,
+)
 
 # Dummy database stub
 class DummyDB:
@@ -13,6 +19,7 @@ class DummyDB:
         self.register_message_called = False
         self.checked_user = False
         self.history = []
+        self.messages = set()
 
     async def add_history(self, uid, role, content, important=False):
         self.history.append((uid, role, content, important))
@@ -28,10 +35,14 @@ class DummyDB:
 
     async def register_message(self, message, message_sent):
         self.register_message_called = True
+        self.messages.add(message_sent.message_id)
 
     async def check_user(self, message):
         self.checked_user = True
         return False
+
+    async def is_bot_message(self, msg_id):
+        return msg_id in self.messages
 
 db_stub = DummyDB()
 
@@ -267,6 +278,46 @@ async def test_reply_fork_new_user(application, bot, monkeypatch):
         await handlers.bot_reply_handler(update, context)
         assert reply_mock.await_count == 2
     assert (55, "assistant", "Bot message", True) in db_stub.history
+
+
+@pytest.mark.asyncio
+async def test_mention_reply_with_context(application, bot, monkeypatch):
+    original = create_message(bot, "Original", user_id=55, message_id=70)
+    message = create_message(bot, "@ai_bot yes", reply_to_msg=original, message_id=71)
+    update = Update(update_id=20, message=message)
+    context = await create_context(update, application)
+    captured = {}
+    monkeypatch.setattr(handlers.messages, "generic_chat", lambda p, text, uid, **k: captured.setdefault("text", text) or "DAN:ok")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.mention_handler(update, context)
+        send_mock.assert_awaited_once()
+    assert "Original" in captured["text"]
+
+
+@pytest.mark.asyncio
+async def test_reaction_handler(application, bot, monkeypatch):
+    from telegram import MessageReactionUpdated, ReactionTypeEmoji
+    from datetime import datetime
+    db_stub.messages.add(80)
+    mr = MessageReactionUpdated(chat=create_chat(-100), message_id=80, date=datetime.now(), old_reaction=[], new_reaction=[ReactionTypeEmoji("😡")], user=create_user(55))
+    update = Update(update_id=21, message_reaction=mr)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers.messages, "generic_chat", lambda *a, **k: "DAN:r")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.reaction_handler(update, context)
+        send_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_handler(application, bot, monkeypatch):
+    other_chat = create_chat(-200, title="Source")
+    message = create_message(bot, "Forwarded", forward_from_chat=other_chat)
+    update = Update(update_id=22, message=message)
+    context = await create_context(update, application)
+    monkeypatch.setattr(handlers.messages, "generic_chat", lambda *a, **k: "DAN:f")
+    with patch("telegram.Bot.send_message", new=AsyncMock()) as send_mock:
+        await handlers.forward_message_handler(update, context)
+        send_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- document supported message types
- react to forwarded posts and channel forwards
- react to negative emoji reactions
- include replied message text when bot is mentioned
- expose new handlers and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751dfc0b9c8327b1f2cc9db201617e